### PR TITLE
fix: vue import

### DIFF
--- a/src/extractors/frameworks/vue.ts
+++ b/src/extractors/frameworks/vue.ts
@@ -5,7 +5,7 @@ import prettier from "prettier/standalone";
 import prettierHtml from "prettier/parser-html";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import Vue from "vue/dist/vue";
+import Vue from "vue";
 import { StoryContext } from "@storybook/addons";
 import { getStory } from "../storyHelper";
 


### PR DESCRIPTION
## Description
This pr resolves these issues [storybook-zeplin](https://github.com/mertkahyaoglu/storybook-zeplin/issues/74) and fixes #11.
## Solution
Just import vue with `import Vue from "vue";` instead of `import Vue from "vue/dist/vue";`.

I've tested this solution on react+storybook project with `pnpm`using this patched version of the package https://github.com/Luk-z/storybook-inspector/tree/v0.1.3-patch.2 and it works
