### PR TITLE
fix!: disable vue component extractors

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,20 +20,22 @@
     "url": "https://github.com/zeplin/storybook-inspector/issues"
   },
   "homepage": "https://github.com/zeplin/storybook-inspector#readme",
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "prettier": "^2.4.1",
+    "vue": "^2.6.14 || ^3.0.0"
+  },
   "dependencies": {
     "lit-html": "^2.0.0-rc.3",
-    "prettier": "^2.4.1",
-    "query-string": "^7.0.1",
-    "react": "^16.14.0",
-    "react-element-to-jsx-string": "^14.3.2",
-    "vue": "^2.6.14"
+    "react-element-to-jsx-string": "^15.0.0",
+    "query-string": "^7.0.1"
   },
   "devDependencies": {
-    "@storybook/addons": "^6.4.14",
-    "@storybook/client-api": "^6.4.14",
+    "@storybook/addons": "^6.5.16",
+    "@storybook/client-api": "^6.5.16",
     "@storybook/csf": "^0.0.2--canary.87bc651.0",
     "@types/prettier": "^2.4.1",
-    "@types/react": "^16.14.0",
+    "@types/react": "^18.0.27",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "@zeplin/eslint-config": "^2.3.2",

--- a/src/extractors/frameworks/index.ts
+++ b/src/extractors/frameworks/index.ts
@@ -1,5 +1,5 @@
 export * from "./react";
-export * from "./vue";
+// Export * from "./vue";
 export * from "./angular";
 export * from "./webComponents";
 export * from "./svelte";

--- a/src/extractors/frameworks/vue.ts
+++ b/src/extractors/frameworks/vue.ts
@@ -3,9 +3,7 @@
 
 import prettier from "prettier/standalone";
 import prettierHtml from "prettier/parser-html";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import Vue from "vue/dist/vue";
+import Vue from "vue";
 import { StoryContext } from "@storybook/addons";
 import { getStory } from "../storyHelper";
 

--- a/src/extractors/getCodeLanguage.ts
+++ b/src/extractors/getCodeLanguage.ts
@@ -2,7 +2,7 @@ import { StoryContext } from "@storybook/addons";
 import {
     getReactCodeLanguage,
     getAngularCodeLanguage,
-    getVueCodeLanguage,
+    // GetVueCodeLanguage,
     getSvelteCodeLanguage,
     getWebComponentsCodeLanguage
 } from "./frameworks";
@@ -12,8 +12,8 @@ const codeLanguageFunctionMapper = new Map<string, (c: StoryContext, gc: GlobalC
     ["angular", getAngularCodeLanguage],
     ["react", getReactCodeLanguage],
     ["svelte", getSvelteCodeLanguage],
-    ["web-components", getWebComponentsCodeLanguage],
-    ["vue", getVueCodeLanguage]
+    ["web-components", getWebComponentsCodeLanguage]
+    // ["vue", getVueCodeLanguage]
 ]);
 
 export function getCodeLanguage(context: StoryContext, globalContext: GlobalContext): string | undefined {

--- a/src/extractors/getCodeSnippetFromStoryFn.ts
+++ b/src/extractors/getCodeSnippetFromStoryFn.ts
@@ -4,8 +4,8 @@ import {
     getAngularCodeSnippet,
     getReactCodeSnippet,
     getSvelteCodeSnippet,
-    getWebComponentsCodeSnippet,
-    getVueCodeSnippet
+    getWebComponentsCodeSnippet
+    // GetVueCodeSnippet
 } from "./frameworks";
 import { getStory } from "./storyHelper";
 
@@ -13,8 +13,8 @@ const codeSnippetMapper = new Map<string, (c: StoryContext) => string | undefine
     ["react", getReactCodeSnippet],
     ["angular", getAngularCodeSnippet],
     ["web-components", getWebComponentsCodeSnippet],
-    ["svelte", getSvelteCodeSnippet],
-    ["vue", getVueCodeSnippet]
+    ["svelte", getSvelteCodeSnippet]
+    // ["vue", getVueCodeSnippet]
 ]);
 
 export function getSnippetFromStoryFn(context: StoryContext): string | undefined {

--- a/src/extractors/getComponentName.ts
+++ b/src/extractors/getComponentName.ts
@@ -2,15 +2,15 @@ import { StoryContext } from "@storybook/addons";
 import {
     getReactComponentName,
     getAngularComponentName,
-    getVueComponentName,
+    // GetVueComponentName,
     getSvelteComponentName
 } from "./frameworks";
 
 const componentNameFunctionMapper = new Map<string, (c: StoryContext) => string | undefined>([
     ["react", getReactComponentName],
     ["angular", getAngularComponentName],
-    ["svelte", getSvelteComponentName],
-    ["vue", getVueComponentName]
+    ["svelte", getSvelteComponentName]
+    // ["vue", getVueComponentName]
 ]);
 
 export function getComponentName(context: StoryContext): string | undefined {

--- a/src/extractors/getFilePath.ts
+++ b/src/extractors/getFilePath.ts
@@ -1,5 +1,9 @@
 import { StoryContext } from "@storybook/addons";
-import { getReactFilePath, getAngularFilePath, getVueFilePath } from "./frameworks";
+import {
+    getReactFilePath,
+    getAngularFilePath
+    // GetVueFilePath
+} from "./frameworks";
 import { GlobalContext } from "../globalContext";
 
 function getStoryFilePath(context: StoryContext): string | undefined {
@@ -9,8 +13,8 @@ function getStoryFilePath(context: StoryContext): string | undefined {
 
 const filePathFunctionMapper = new Map<string, (c: StoryContext, gc: GlobalContext) => string | undefined>([
     ["react", getReactFilePath],
-    ["angular", getAngularFilePath],
-    ["vue", getVueFilePath]
+    ["angular", getAngularFilePath]
+    // ["vue", getVueFilePath]
 ]);
 
 export function getFilePath(context: StoryContext, globalContext: GlobalContext): string | undefined {

--- a/src/globalContext.ts
+++ b/src/globalContext.ts
@@ -41,8 +41,8 @@ export async function getGlobalContext(
 ): Promise<GlobalContext> {
     if (!windowObject ||
         !(windowObject instanceof Object) ||
-        !("0" in windowObject) ||
-        !("__STORYBOOK_CLIENT_API__" in windowObject[0])) {
+        !(typeof windowObject === "object" && "0" in windowObject) ||
+        !(windowObject[0] && typeof windowObject[0] === "object" && "__STORYBOOK_CLIENT_API__" in windowObject[0])) {
         if (retryCount === 0) {
             throw new Error("Timeout while getting Storybook Client API");
         }


### PR DESCRIPTION
Vue dependencies creates a conflict on projects without vue package Extractors are dependent on runtime information to decide whether to use Vue dependencies or not, it is not possible to eliminate unnecessary package imports on the bundled package.

Anyway, current Vue extractors does not work even for Vue3 projects.

Disabling vue extractors in order to let other projects work without issues. Disabling them only affects generating file path and code snippet. It won't affect to get story info to be used on Zeplin, we can still use them to create SB URLs for Vue components.

Next step should to split Storybook integration functionalities of storybook-zeplin addon into individual addons for each supported framework.

## Description
<!-- Please include a summary of your changes here. -->

## Checklist
<!--
Make sure these boxes are checked before submitting your PR — thank you!

Put an `x` in the boxes that apply. You can also fill these out after creating the PR.  This is a gentle reminder of what you need to do before submitting a PR
-->
- [x] My PR has a relevant title.
- [x] My PR has a clear and complete description.
- [x] I have performed a self-review of my own change.
